### PR TITLE
feat: Add Pointer Support

### DIFF
--- a/docs/pointers.md
+++ b/docs/pointers.md
@@ -1,0 +1,50 @@
+ # Pointers in VintLang
+
+VintLang now supports basic pointer operations, allowing you to reference and dereference values in your programs. This feature enables more advanced data manipulation and can be useful for certain algorithms and data structures.
+
+## Syntax
+
+- **Address-of:** Use `&` to get a pointer to a value.
+- **Dereference:** Use `*` to access the value pointed to by a pointer.
+
+## Usage
+
+### Creating a Pointer
+```vint
+let x = 42
+let p = &x  # p is now a pointer to the value of x
+```
+
+### Dereferencing a Pointer
+```vint
+print(*p)  # prints 42
+```
+
+### Printing a Pointer
+```vint
+print(p)  # prints something like Pointer(42) or Pointer(addr=0x..., value=42)
+```
+
+## Limitations
+- **Pointers in VintLang are pointers to values, not to variables.**
+  - If you change the value of `x` after creating `p = &x`, the pointer `p` will still point to the original value, not the updated value of `x`.
+- You cannot assign through a pointer (e.g., `*p = 100` is not supported).
+- Pointers to literals (e.g., `let p = &42`) are allowed, but they are just pointers to the value at the time of creation.
+
+## Example
+```vint
+let x = 10
+let p = &x
+print(p)    # Pointer(10)
+print(*p)   # 10
+x = 20
+print(*p)   # Still 10, because p points to the original value
+```
+
+## Error Handling
+- Dereferencing a non-pointer or a nil pointer will result in a runtime error.
+
+## Summary
+- Use `&` to create pointers to values.
+- Use `*` to dereference pointers.
+- Pointers are useful for referencing values, but do not provide full variable reference semantics.

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -16,6 +16,7 @@ var (
 )
 
 func Eval(node ast.Node, env *object.Environment) object.Object {
+	fmt.Printf("EVAL DEBUG: node type=%T, node=%#v\n", node, node)
 	switch node := node.(type) {
 	case *ast.Program:
 		return evalProgram(node, env)
@@ -302,7 +303,6 @@ func applyFunction(fn object.Object, args []object.Object, line int) object.Obje
 		}
 	}
 }
-
 
 func extendedFunctionEnv(fn *object.Function, args []object.Object) *object.Environment {
 	env := object.NewEnclosedEnvironment(fn.Env)

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -16,7 +16,6 @@ var (
 )
 
 func Eval(node ast.Node, env *object.Environment) object.Object {
-	fmt.Printf("EVAL DEBUG: node type=%T, node=%#v\n", node, node)
 	switch node := node.(type) {
 	case *ast.Program:
 		return evalProgram(node, env)

--- a/evaluator/prefix.go
+++ b/evaluator/prefix.go
@@ -38,11 +38,14 @@ func evalPrefixExpression(operator string, right object.Object, line int) object
 	case "+":
 		return evalPlusPrefixOperatorExpression(right, line)
 	case "*":
-		// Dereference: expect a Pointer object, return its Ref
+		// derefences a pointer to get the value
 		if p, ok := right.(*object.Pointer); ok {
 			return p.Ref
 		}
 		return newError("Line %d: cannot dereference non-pointer", line)
+	case "&":
+		// Creates a new Pointer object that points to the value
+		return &object.Pointer{Ref: right}
 	default:
 		return newError("Line %d: Unknown operation: %s%s", line, operator, right.Type())
 	}

--- a/evaluator/prefix.go
+++ b/evaluator/prefix.go
@@ -1,6 +1,10 @@
 package evaluator
 
-import "github.com/vintlang/vintlang/object"
+import (
+	"fmt"
+
+	"github.com/vintlang/vintlang/object"
+)
 
 func evalMinusPrefixOperatorExpression(right object.Object, line int) object.Object {
 	switch obj := right.(type) {
@@ -30,6 +34,8 @@ func evalPlusPrefixOperatorExpression(right object.Object, line int) object.Obje
 }
 
 func evalPrefixExpression(operator string, right object.Object, line int) object.Object {
+	fmt.Printf("DEBUG: operator=%s, right=%T, value=%v\n", operator, right, right)
+
 	switch operator {
 	case "!":
 		return evalBangOperatorExpression(right)
@@ -38,13 +44,20 @@ func evalPrefixExpression(operator string, right object.Object, line int) object
 	case "+":
 		return evalPlusPrefixOperatorExpression(right, line)
 	case "*":
-		// derefences a pointer to get the value
+		if right == nil {
+			return newError("Line %d: cannot dereference nil", line)
+		}
 		if p, ok := right.(*object.Pointer); ok {
+			if p.Ref == nil {
+				return newError("Line %d: pointer is nil", line)
+			}
 			return p.Ref
 		}
 		return newError("Line %d: cannot dereference non-pointer", line)
 	case "&":
-		// Creates a new Pointer object that points to the value
+		if right == nil {
+			return newError("Line %d: cannot take address of nil", line)
+		}
 		return &object.Pointer{Ref: right}
 	default:
 		return newError("Line %d: Unknown operation: %s%s", line, operator, right.Type())

--- a/evaluator/prefix.go
+++ b/evaluator/prefix.go
@@ -1,8 +1,6 @@
 package evaluator
 
 import (
-	"fmt"
-
 	"github.com/vintlang/vintlang/object"
 )
 
@@ -34,8 +32,6 @@ func evalPlusPrefixOperatorExpression(right object.Object, line int) object.Obje
 }
 
 func evalPrefixExpression(operator string, right object.Object, line int) object.Object {
-	fmt.Printf("DEBUG: operator=%s, right=%T, value=%v\n", operator, right, right)
-
 	switch operator {
 	case "!":
 		return evalBangOperatorExpression(right)

--- a/evaluator/prefix.go
+++ b/evaluator/prefix.go
@@ -37,6 +37,12 @@ func evalPrefixExpression(operator string, right object.Object, line int) object
 		return evalMinusPrefixOperatorExpression(right, line)
 	case "+":
 		return evalPlusPrefixOperatorExpression(right, line)
+	case "*":
+		// Dereference: expect a Pointer object, return its Ref
+		if p, ok := right.(*object.Pointer); ok {
+			return p.Ref
+		}
+		return newError("Line %d: cannot dereference non-pointer", line)
 	default:
 		return newError("Line %d: Unknown operation: %s%s", line, operator, right.Type())
 	}

--- a/examples/pointers.vint
+++ b/examples/pointers.vint
@@ -1,3 +1,4 @@
 let x = 42
 let p = &x
-print(*p)  # Should print 42 
+print(*p)
+# Should print 42 

--- a/examples/pointers.vint
+++ b/examples/pointers.vint
@@ -3,3 +3,6 @@ let x = 42
 let p = &x
 print(p)
 print("POINTER is",p)
+
+//Will Output something like
+// POINTER is Pointer(addr=0x14000010560, value=42)

--- a/examples/pointers.vint
+++ b/examples/pointers.vint
@@ -1,4 +1,5 @@
+print("POINTER IN VINTLANG")
 let x = 42
 let p = &x
 print(*p)
-# Should print 42 
+// Should print 42 

--- a/examples/pointers.vint
+++ b/examples/pointers.vint
@@ -3,6 +3,7 @@ let x = 42
 let p = &x
 print(p)
 print("POINTER is",p)
+print("VALUE is",*p)
 
 //Will Output something like
 // POINTER is Pointer(addr=0x14000010560, value=42)

--- a/examples/pointers.vint
+++ b/examples/pointers.vint
@@ -1,0 +1,3 @@
+let x = 42
+let p = &x
+print(*p)  # Should print 42 

--- a/examples/pointers.vint
+++ b/examples/pointers.vint
@@ -1,5 +1,5 @@
-print("POINTER IN VINTLANG")
+print("POINTERs IN VINTLANG")
 let x = 42
 let p = &x
-print(*p)
-// Should print 42 
+print(p)
+print("POINTER is",p)

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -130,7 +130,7 @@ func (l *Lexer) NextToken() token.Token {
 		} else {
 			tok = newToken(token.GT, l.line, l.ch)
 		}
-		
+
 	case rune('"'):
 		tok.Type = token.STRING
 		tok.Literal = l.readString()
@@ -152,6 +152,8 @@ func (l *Lexer) NextToken() token.Token {
 			ch := l.ch
 			l.readChar()
 			tok = token.Token{Type: token.AND, Literal: string(ch) + string(l.ch), Line: l.line}
+		} else {
+			tok = newToken(token.AMPERSAND, l.line, l.ch)
 		}
 	case rune('|'):
 		if l.peekChar() == rune('|') {

--- a/object/object.go
+++ b/object/object.go
@@ -29,7 +29,8 @@ const (
 	BYTE_OBJ         = "BYTE"
 	PACKAGE_OBJ      = "PACKAGE"
 	INSTANCE         = "INSTANCE"
-	NATIVE_OBJ         = "NATIVE_OBJ"
+	NATIVE_OBJ       = "NATIVE_OBJ"
+	POINTER_OBJ      = "POINTER"
 	AT               = "@"
 )
 

--- a/object/pointer.go
+++ b/object/pointer.go
@@ -13,5 +13,3 @@ func (p *Pointer) Type() ObjectType {
 func (p *Pointer) Inspect() string {
 	return fmt.Sprintf("Pointer(%s)", p.Ref.Inspect())
 }
-
-const POINTER_OBJ = "POINTER"

--- a/object/pointer.go
+++ b/object/pointer.go
@@ -11,5 +11,5 @@ func (p *Pointer) Type() ObjectType {
 }
 
 func (p *Pointer) Inspect() string {
-	return fmt.Sprintf("Pointer(%s)", p.Ref.Inspect())
+    return fmt.Sprintf("Pointer(addr=%p, value=%s)", p.Ref, p.Ref.Inspect())
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -105,6 +105,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
 	p.registerPrefix(token.PLUS, p.parsePrefixExpression)
 	p.registerPrefix(token.AMPERSAND, p.parsePrefixExpression)
+	p.registerPrefix(token.ASTERISK, p.parsePrefixExpression)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
 	p.registerPrefix(token.FALSE, p.parseBoolean)
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -271,6 +271,8 @@ func (p *Parser) parsePrefixExpression() ast.Expression {
 
 	expression.Right = p.parseExpression(PREFIX)
 
+	fmt.Printf("PARSER DEBUG: PrefixExpression Operator=%s, Right=%#v\n", expression.Operator, expression.Right)
+
 	return expression
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -271,8 +271,6 @@ func (p *Parser) parsePrefixExpression() ast.Expression {
 
 	expression.Right = p.parseExpression(PREFIX)
 
-	fmt.Printf("PARSER DEBUG: PrefixExpression Operator=%s, Right=%#v\n", expression.Operator, expression.Right)
-
 	return expression
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -73,7 +73,7 @@ type Parser struct {
 	postfixParseFns map[token.TokenType]postfixParseFn
 }
 
-//adds error
+// adds error
 func (p *Parser) addError(msg string) {
 	p.errors = append(p.errors, msg)
 }
@@ -104,6 +104,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
 	p.registerPrefix(token.PLUS, p.parsePrefixExpression)
+	p.registerPrefix(token.AMPERSAND, p.parsePrefixExpression)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
 	p.registerPrefix(token.FALSE, p.parseBoolean)
 	p.registerPrefix(token.LPAREN, p.parseGroupedExpression)

--- a/token/token.go
+++ b/token/token.go
@@ -18,15 +18,13 @@ const (
 	STRING = "STRING"
 	FLOAT  = "FLOAT"
 
-	POINTER = "POINTER" // *
-	ADDRESS = "ADDRESS" // &
-
 	// Operators
 	ASSIGN          = "="
 	PLUS            = "+"
 	MINUS           = "-"
 	BANG            = "!"
 	ASTERISK        = "*"
+	AMPERSAND       = "&"
 	POW             = "**"
 	SLASH           = "/"
 	MODULUS         = "%"


### PR DESCRIPTION
This PR introduces basic pointer support to VintLang, allowing for more advanced data manipulation.

**Key Features:**
- **Address-of Operator (`&`):** Get a pointer to the value of a variable.
- **Dereference Operator (`*`):** Access the value a pointer refers to.

**Implementation Details:**
- **Lexer:** Added `AMPERSAND` (`&`) and `ASTERISK` (`*`) as tokens. `&` is now correctly tokenized as a single operator.
- **Parser:** Registered `&` and `*` as prefix operators, allowing expressions like `&x` and `*p`.
- **Object System:** Introduced a new `object.Pointer` type to represent pointers at runtime.
- **Evaluator:** Implemented logic to handle the creation of pointers (`&`) and dereferencing (`*`). Includes defensive checks for nil and non-pointer values.
- **Documentation:** Added `docs/pointers.md` explaining the new feature, its syntax, and its current limitations (value pointers, not variable references).

**Example Usage:**
```vint
let x = 42
let p = &x  // p is a pointer to the value of x

print(p)    // Prints the pointer's representation
print(*p)   // Prints 42
```

This feature lays the groundwork for more complex memory management and data structure implementations in the future.