### PR TITLE
parser: improve error messages for reserved keywords

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -258,6 +258,16 @@ func (p *Parser) Errors() []string {
 }
 
 func (p *Parser) peekError(t token.TokenType) {
+	if t == token.IDENT && token.IsKeyword(p.peekToken.Type) {
+		kw := token.KeywordLiteral(p.peekToken.Type)
+		if kw == "" {
+			kw = p.peekToken.Literal
+		}
+		msg := fmt.Sprintf("%s:%d: '%s' is a reserved keyword and cannot be used as an identifier. Try a different name, e.g. '%s_val' or 'my_%s'",
+			p.l.GetFilename(), p.peekToken.Line, kw, kw, kw)
+		p.errors = append(p.errors, msg)
+		return
+	}
 	msg := fmt.Sprintf("%s:%d: Expected next token to be %s, got %s instead", p.l.GetFilename(), p.peekToken.Line, t, p.peekToken.Type)
 	p.errors = append(p.errors, msg)
 }
@@ -287,8 +297,22 @@ func (p *Parser) synchronize() {
 	}
 }
 
-// parse expressions
+// skipToNextStatement advances tokens until peekToken is a statement-starting
+// token (or EOF). This is used inside statement parsers (let/const) so that
+// the main ParseProgram loop's nextToken() call will land correctly on the
+// start of the next statement.
+func (p *Parser) skipToNextStatement() {
+	for p.peekToken.Type != token.EOF {
+		p.nextToken()
+		switch p.peekToken.Type {
+		case token.LET, token.CONST, token.FUNCTION, token.IF, token.WHILE,
+			token.FOR, token.RETURN, token.SWITCH, token.PACKAGE, token.IMPORT, token.EOF:
+			return
+		}
+	}
+}
 
+// parse expressions
 func (p *Parser) parseExpressionStatement() *ast.ExpressionStatement {
 	stmt := &ast.ExpressionStatement{Token: p.curToken}
 
@@ -328,7 +352,6 @@ func (p *Parser) parseExpression(precedence int) ast.Expression {
 }
 
 // prefix expressions
-
 func (p *Parser) parsePrefixExpression() ast.Expression {
 	expression := &ast.PrefixExpression{
 		Token:    p.curToken,
@@ -343,6 +366,16 @@ func (p *Parser) parsePrefixExpression() ast.Expression {
 }
 
 func (p *Parser) noPrefixParseFnError(t token.TokenType) {
+	if token.IsKeyword(t) {
+		kw := token.KeywordLiteral(t)
+		if kw == "" {
+			kw = p.curToken.Literal
+		}
+		msg := fmt.Sprintf("%s:%d: '%s' is a reserved keyword and cannot be used as a value or identifier here",
+			p.l.GetFilename(), p.curToken.Line, kw)
+		p.errors = append(p.errors, msg)
+		return
+	}
 	msg := fmt.Sprintf("%s:%d: Unexpected token '%s' - this token cannot start an expression. Check for missing operands or invalid syntax", p.l.GetFilename(), p.curToken.Line, t)
 	p.errors = append(p.errors, msg)
 }
@@ -375,6 +408,16 @@ func (p *Parser) parseRangeExpression(left ast.Expression) ast.Expression {
 }
 
 func (p *Parser) noInfixParseFnError(t token.TokenType) {
+	if token.IsKeyword(t) {
+		kw := token.KeywordLiteral(t)
+		if kw == "" {
+			kw = p.curToken.Literal
+		}
+		msg := fmt.Sprintf("%s:%d: '%s' is a reserved keyword and cannot be used in this context. Check syntax for operators, expressions, or missing semicolon",
+			p.l.GetFilename(), p.curToken.Line, kw)
+		p.errors = append(p.errors, msg)
+		return
+	}
 	msg := fmt.Sprintf("%s:%d: Unexpected token '%s' - cannot be used in this context. Check syntax for operators, expressions, or missing semicolon", p.l.GetFilename(), p.curToken.Line, t)
 	p.errors = append(p.errors, msg)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/vintlang/vintlang/ast"
@@ -602,11 +603,13 @@ func TestParserErrors(t *testing.T) {
 		expectedErrors int
 	}{
 		{"let x 5;", 1},            // missing =
-		{"let = 5;", 2},            // missing identifier and invalid prefix
+		{"let = 5;", 1},            // missing identifier (cascade suppressed)
 		{"5 + ;", 1},               // incomplete expression
 		{"if x { }", 1},            // missing parentheses
 		{"func() { return ; }", 1}, // invalid return expression (semicolon)
 		{"let x = 5", 0},           // valid without semicolon
+		{"let info = 5", 1},        // reserved keyword as identifier
+		{"const match = 1", 1},     // reserved keyword as identifier
 	}
 
 	for _, tt := range tests {
@@ -616,8 +619,51 @@ func TestParserErrors(t *testing.T) {
 
 		errors := p.Errors()
 		if len(errors) != tt.expectedErrors {
-			t.Errorf("input %q: expected %d errors, got %d. Errors: %v", 
+			t.Errorf("input %q: expected %d errors, got %d. Errors: %v",
 				tt.input, tt.expectedErrors, len(errors), errors)
+		}
+	}
+}
+
+func TestReservedKeywordAsIdentifier(t *testing.T) {
+	tests := []struct {
+		input   string
+		keyword string
+	}{
+		{"let info = 5", "info"},
+		{"let debug = 5", "debug"},
+		{"let log = 5", "log"},
+		{"let match = 5", "match"},
+		{"let success = true", "success"},
+		{"const error = 1", "error"},
+		{"let warn = 1", "warn"},
+		{"let note = 1", "note"},
+		{"let todo = 1", "todo"},
+		{"let for = 1", "for"},
+		{"let if = 1", "if"},
+		{"let while = 1", "while"},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		p.ParseProgram()
+
+		errors := p.Errors()
+		if len(errors) == 0 {
+			t.Errorf("input %q: expected error for reserved keyword %q, got none", tt.input, tt.keyword)
+			continue
+		}
+
+		found := false
+		for _, err := range errors {
+			if strings.Contains(err, "'"+tt.keyword+"' is a reserved keyword") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("input %q: expected reserved keyword error for %q, got: %v", tt.input, tt.keyword, errors)
 		}
 	}
 }

--- a/parser/statements.go
+++ b/parser/statements.go
@@ -36,6 +36,7 @@ func (p *Parser) parseLetStatement() *ast.LetStatement {
 	stmt := &ast.LetStatement{Token: p.curToken}
 
 	if !p.expectPeek(token.IDENT) {
+		p.skipToNextStatement()
 		return nil
 	}
 
@@ -60,6 +61,7 @@ func (p *Parser) parseConstStatement() *ast.ConstStatement {
 	stmt := &ast.ConstStatement{Token: p.curToken}
 
 	if !p.expectPeek(token.IDENT) {
+		p.skipToNextStatement()
 		return nil
 	}
 

--- a/token/token.go
+++ b/token/token.go
@@ -193,3 +193,24 @@ func LookupIdent(ident string) TokenType {
 	}
 	return IDENT
 }
+
+// IsKeyword returns true if the given TokenType corresponds to a reserved keyword.
+func IsKeyword(t TokenType) bool {
+	for _, tok := range keywords {
+		if tok == t {
+			return true
+		}
+	}
+	return false
+}
+
+// KeywordLiteral returns the source-level keyword string for a token type,
+// e.g. INFO -> "info", FUNCTION -> "func". Returns "" if not a keyword.
+func KeywordLiteral(t TokenType) string {
+	for literal, tok := range keywords {
+		if tok == t {
+			return literal
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Enhance error reporting for reserved keywords used as identifiers. This change provides clearer messages when users attempt to use reserved keywords as variable names, guiding them to choose alternative identifiers. Additional tests ensure that these error messages are triggered correctly.

