### PR TITLE
Remove '@' character from isLetter function to refine identifier validation

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -331,7 +331,7 @@ func (l *Lexer) readIdentifier() string {
 }
 
 func isLetter(ch rune) bool {
-	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_' || ch == '@'
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
 }
 
 func (l *Lexer) skipWhitespace() {


### PR DESCRIPTION
Remove the '@' character from the `isLetter` function to improve identifier validation. This change ensures that only valid characters are accepted for identifiers, enhancing the overall integrity of the lexer.

